### PR TITLE
The browser should also handle file:// type requests, no?

### DIFF
--- a/lib/launchy/browser.rb
+++ b/lib/launchy/browser.rb
@@ -26,7 +26,7 @@ module Launchy
         begin
           Launchy.log "#{self.name} : testing if [#{args[0]}] (#{args[0].class}) is a url."
           uri = URI.parse(args[0])
-          result =  [URI::HTTP, URI::HTTPS, URI::FTP].include?(uri.class)
+          result =  [URI::HTTP, URI::HTTPS, URI::FTP].include?(uri.class) || uri.scheme == 'file'
         rescue Exception => e
           # hmm... why does rcov not see that this is executed ?
           Launchy.log "#{self.name} : not a url, #{e}"

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -21,6 +21,10 @@ describe Launchy::Browser do
     Launchy::Browser.handle?("ftp://download.example.com").should == true
   end
 
+  it "should handle a file url" do
+    Launchy::Browser.handle?("file://local/file.html").should == true
+  end
+
   it "should not handle a mailto url" do
     Launchy::Browser.handle?("mailto:jeremy@example.com").should == false
   end


### PR DESCRIPTION
This tripped me up when trying to use Launchy.open as opposed to Launchy::Browser.run on a local file.

The difference ended up being Browser#handle?

Cheers,
Robert
