### PR TITLE
Enable use of master branch with Bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *~
 *.swo
 *.swp
+*.gem
 doc/
 coverage/
 pkg/
+.bundle
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+
+# Specify your gem's dependencies in launchy.gemspec
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,53 +1,23 @@
-#--
-# Copyright (c) 2007 Jeremy Hinegardner
-# All rights reserved.  See LICENSE and/or COPYING for details.
-#++
+require 'bundler'
+Bundler::GemHelper.install_tasks
 
-begin
-  require 'bones'
-rescue LoadError
-  abort '### Please install the "bones" gem ###'
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.pattern = 'spec/**/*_spec.rb'
 end
 
-task :default => 'test:run'
-task 'gem:release' => 'test:run'
-
-$:.unshift( "lib" )
-require 'launchy/version'
-
-Bones {
-  name      "launchy"
-  author    "Jeremy Hinegardner"
-  email     "jeremy@copiousfreetime.org"
-  url       'http://www.copiousfreetime.org/projects/launchy'
-  version   Launchy::VERSION
-
-  ruby_opts     %w[ -W0 -rubygems ]
-  readme_file   'README'
-  ignore_file   '.gitignore'
-  history_file  'HISTORY'
-
-  rdoc.include << "README" << "HISTORY" << "LICENSE"
-
-  summary 'Launchy is helper class for launching cross-platform applications in a fire and forget manner.'
-  description <<_
-Launchy is helper class for launching cross-platform applications in a
-fire and forget manner.
-
-There are application concepts (browser, email client, etc) that are
-common across all platforms, and they may be launched differently on
-each platform.  Launchy is here to make a common approach to launching
-external application from within ruby programs.
-_
-
-  if RUBY_PLATFORM == "java" then
-    depend_on "spoon"   , "~> 0.0.1"
-    gem.extras = { :platform => Gem::Platform.new( "java" ) }
+namespace(:test) do
+  desc 'Run all tests on multiple ruby versions (requires rvm)'
+  task(:portability) do
+    %w[1.8.7 1.9.2 jruby-1.6.1].each do |version|
+      system <<-BASH
+        bash -c 'source ~/.rvm/scripts/rvm;
+                 rvm #{version};
+                 echo "--------- version #{version} ----------\n";
+                 bundle install;
+                 rake test'
+      BASH
+    end
   end
-
-  depend_on "rake"    , "~> 0.8.7", :development => true
-  depend_on "minitest", "~> 2.0.2", :development => true
-  depend_on 'bones'   , "~> 3.6.5", :development => true
-
-  test.files = FileList["spec/**/*_spec.rb"]
-}
+end

--- a/launchy.gemspec
+++ b/launchy.gemspec
@@ -1,0 +1,41 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path('../lib', __FILE__)
+require 'launchy/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'launchy'
+  s.version     = Launchy::VERSION
+  s.platform    = Gem::Platform::CURRENT
+  s.authors     = ['Jeremy Hinegardner']
+  s.email       = ['jeremy@copiousfreetime.org']
+  s.homepage    = 'http://www.copiousfreetime.org/projects/launchy'
+  s.summary     = 'Launchy is helper class for launching cross-platform applications in a fire and forget manner.'
+  s.description = <<_
+Launchy is helper class for launching cross-platform applications in a
+fire and forget manner.
+
+There are application concepts (browser, email client, etc) that are
+common across all platforms, and they may be launched differently on
+each platform. Launchy is here to make a common approach to launching
+external application from within ruby programs.
+_
+
+  s.required_rubygems_version = '>= 1.3.6'
+  s.rubyforge_project         = 'launchy'
+
+  if RUBY_PLATFORM == 'java' then
+    s.add_dependency 'spoon', '~> 0.0.1'
+  end
+
+  s.add_development_dependency 'bundler',  '~> 1.0.13'
+  s.add_development_dependency 'rake',     '~> 0.8.7'
+  s.add_development_dependency 'minitest', '~> 2.1.0'
+
+  s.files        = Dir.glob('{lib}/**/*') + %w[LICENSE README HISTORY]
+  s.require_path = 'lib'
+
+  s.rdoc_options = ["--title", "Launchy", "--main", "README", "--line-numbers"]
+  s.extra_rdoc_files = %w[LICENSE README HISTORY]
+
+  s.test_files = Dir.glob('spec/**')
+end

--- a/spec/launchy/application_spec.rb
+++ b/spec/launchy/application_spec.rb
@@ -1,14 +1,14 @@
-require File.join(File.dirname(__FILE__),"spec_helper.rb")
+require File.expand_path(File.join(File.dirname(__FILE__),"..","spec_helper"))
 require 'yaml'
 
 describe Launchy::Application do
   before(:each) do
-    yml = YAML::load(IO.read(File.join(File.dirname(__FILE__),"tattle-host-os.yml")))
+    yml = YAML::load(IO.read(File.join(File.dirname(__FILE__),"..","tattle-host-os.yml")))
     @host_os = yml['host_os']
     @app = Launchy::Application.new
   end
 
-  YAML::load(IO.read(File.join(File.dirname(__FILE__), "tattle-host-os.yml")))['host_os'].keys.sort.each do |os|
+  YAML::load(IO.read(File.join(File.dirname(__FILE__),"..", "tattle-host-os.yml")))['host_os'].keys.sort.each do |os|
     it "#{os} should be a found os" do
       Launchy::Application::known_os_families.must_include( @app.my_os_family(os) )
     end
@@ -31,7 +31,7 @@ describe Launchy::Application do
   end
 
   it "should not find app xyzzy" do
-    @app.find_executable('xyzzy').must_be_nil 
+    @app.find_executable('xyzzy').must_be_nil
   end
 
   it "should find the correct class to launch an ftp url" do

--- a/spec/launchy/browser_spec.rb
+++ b/spec/launchy/browser_spec.rb
@@ -1,5 +1,6 @@
-require File.join(File.dirname(__FILE__),"spec_helper.rb")
+require File.expand_path(File.join(File.dirname(__FILE__),"..","spec_helper"))
 require 'stringio'
+
 describe Launchy::Browser do
   it "should find a path to a executable" do
     begin

--- a/spec/launchy/launchy_spec.rb
+++ b/spec/launchy/launchy_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__),"spec_helper.rb")
+require File.expand_path(File.join(File.dirname(__FILE__),"..","spec_helper"))
 require 'stringio'
 
 describe Launchy do

--- a/spec/launchy/version_spec.rb
+++ b/spec/launchy/version_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__),"spec_helper.rb")
+require File.expand_path(File.join(File.dirname(__FILE__),"..","spec_helper"))
 require 'yaml'
 
 describe "Launchy::VERSION" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 require 'minitest/autorun'
-require 'minitest/pride'
+#require 'minitest/pride'
 
 $: << File.expand_path(File.join(File.dirname(__FILE__),"..","lib"))
 require 'launchy'


### PR DESCRIPTION
The project gemspec enables the use of  launchy master with Bundler by adding
gem 'launchy', :git => 'git://github.com/copiousfreetime/launchy.git'.

This also removes the dependency on the bones gem.

In addition a new test task `test:portability` has been added to test the gem
under Ruby 1.8.7, Ruby 1.9.2 and JRuby 1.6.1.
