### PR TITLE
Use RbConfig instead of obsolete and deprecated Config.

### DIFF
--- a/lib/launchy/application.rb
+++ b/lib/launchy/application.rb
@@ -47,7 +47,7 @@ module Launchy
           Launchy.log "#{self.name} : Using LAUNCHY_HOST_OS override of '#{ENV['LAUNCHY_HOST_OS']}'"
           return ENV['LAUNCHY_HOST_OS']
         else
-          ::Config::CONFIG['host_os']
+          ::RbConfig::CONFIG['host_os']
         end
       end
 


### PR DESCRIPTION
Fixed warning on ruby-head looked like

``` sh
gems/launchy-0.4.0/lib/launchy/application.rb:50: Use RbConfig instead of obsolete and deprecated Config.
```
