### PR TITLE
Don't require 'spoon' on Windows, even under JRuby

### DIFF
--- a/lib/launchy.rb
+++ b/lib/launchy.rb
@@ -40,4 +40,5 @@ require 'launchy/browser'
 require 'launchy/command_line'
 require 'launchy/version'
 
-require 'spoon' if Launchy::Application.is_jruby?
+require 'spoon' if Launchy::Application.my_os_family != :windows and
+                   Launchy::Application.is_jruby?


### PR DESCRIPTION
Using Launchy on JRuby on Windows fails, due to the Launchy's dependency on Spoon under JRuby. Looking at launchy/application.rb, I see that Spoon is not actually used if my_os_family == :windows.

This commit simply adds that windows check to the already conditional require of Spoon.
- Bruce
