### PR TITLE
Dry run can be turn on via LAUNCHY_DRY_RUN environment variable

### DIFF
--- a/lib/launchy.rb
+++ b/lib/launchy.rb
@@ -51,7 +51,7 @@ module Launchy
       Launchy.application  = options.delete( :application ) || ENV['LAUNCHY_APPLICATION']
       Launchy.host_os      = options.delete( :host_os     ) || ENV['LAUNCHY_HOST_OS']
       Launchy.ruby_engine  = options.delete( :ruby_engine ) || ENV['LAUNCHY_RUBY_ENGINE']
-      Launchy.dry_run      = options.delete( :dry_run     )
+      Launchy.dry_run      = options.delete( :dry_run     ) || ENV['LAUNCHY_DRY_RUN']
     end
 
     def debug=( d )

--- a/spec/launchy_spec.rb
+++ b/spec/launchy_spec.rb
@@ -23,6 +23,13 @@ describe Launchy do
     ENV["LAUNCHY_DEBUG"] = nil
   end
 
+  it "sets the global option :dry_run to value of LAUNCHY_DRY_RUN environment variable" do
+    ENV['LAUNCHY_DRY_RUN'] = 'true'
+    Launchy.extract_global_options({})
+    Launchy.dry_run?.must_equal 'true'
+    ENV['LAUNCHY_DRY_RUN'] = nil
+  end
+
   it "has the global option :debug" do
     Launchy.extract_global_options( { :debug => 'true' } )
     Launchy.debug?.must_equal true


### PR DESCRIPTION
I was testing a command line tool in a child process, so I needed somehow tell launchy to just print out the command instead of launching the browser.
