### PR TITLE
Simplify XFCE desktop detection

### DIFF
--- a/lib/launchy/detect/nix_desktop_environment.rb
+++ b/lib/launchy/detect/nix_desktop_environment.rb
@@ -49,7 +49,7 @@ module Launchy::Detect
     class Xfce < NixDesktopEnvironment
       def self.is_current_desktop_environment?
         if Launchy::Application.find_executable( 'xprop' ) then
-          %x[ xprop -root _DT_SAVE_MODE | grep ' = \"xfce\"$' ].strip.size > 0
+          %x[ xprop -root _DT_SAVE_MODE].include?("xfce")
         else
           false
         end


### PR DESCRIPTION
Current expression doesn't work on my machine by some reason.

```
$ xprop -root _DT_SAVE_MODE       
_DT_SAVE_MODE(STRING) = "xfce4"
$ xprop -root _DT_SAVE_MODE | grep ' = \"xfce\"$'       
$
```

I think we can use simpler expression to detect it that doesn't  depend on grep and works for me.
