### PR TITLE
Test `Application.find_executable` with xdg-open as well

### DIFF
--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -30,8 +30,8 @@ describe Launchy::Application do
     lambda { Launchy::Application.handling( uri ) }.must_raise( Launchy::ApplicationNotFoundError )
   end
 
-  it "can find open or curl" do
-    found = %w[ open curl ].any? do |app|
+  it "can find open or curl or xdg-open" do
+    found = %w[ open curl xdg-open ].any? do |app|
       Launchy::Application.find_executable( app )
     end
     found.must_equal true


### PR DESCRIPTION
Neither `open` nor `curl` are available on bare Linux systems, for example inside the Debian's pbuilder environment. This problem is reflected in issue #67.

`xdg-open` is not available as well but is a much smaller package; it is also
arch-independent and has no dependencies.
