### PR TITLE
Issue 71 - Not running under KDE

### DIFF
--- a/lib/launchy/detect/nix_desktop_environment.rb
+++ b/lib/launchy/detect/nix_desktop_environment.rb
@@ -36,7 +36,7 @@ module Launchy::Detect
       end
 
       def self.browser
-        ::Launchy::Argv.new( %w[ kvmclient openURL ] )
+        ::Launchy::Argv.new( %w[ kfmclient openURL ] )
       end
     end
 

--- a/lib/launchy/detect/runner.rb
+++ b/lib/launchy/detect/runner.rb
@@ -37,7 +37,7 @@ module Launchy::Detect
     # and in that case system shell escaping rules are not done.
     #
     def shell_commands( cmd, args )
-      cmdline = [ cmd.shellsplit ]
+      cmdline = [ cmd.to_s.shellsplit ]
       cmdline << args.flatten.collect{ |a| a.to_s }
       return commandline_normalize( cmdline )
     end


### PR DESCRIPTION
- Fixed KDE launcher name, s/kvmclient/kfmclient
- Convert Argv object to its command string before processing it as a
  command line
