### PR TITLE
Avoid use of GNOME when gnome-open isn't present

### DIFF
--- a/lib/launchy/detect/nix_desktop_environment.rb
+++ b/lib/launchy/detect/nix_desktop_environment.rb
@@ -42,7 +42,8 @@ module Launchy::Detect
 
     class Gnome < NixDesktopEnvironment
       def self.is_current_desktop_environment?
-        ENV['GNOME_DESKTOP_SESSION_ID']
+        ENV['GNOME_DESKTOP_SESSION_ID'] &&
+          Launchy::Application.find_executable( 'gnome-open' )
       end
 
       def self.browser


### PR DESCRIPTION
It's possible for some GNOME components to be in use and
GNOME_DESKTOP_SESSION_ID to be set even though gnome-open is not
installed.

Modern Ubuntu installations are like this (reproduced on Trusty).

The result is that Launchy will incorrectly determine the current
environment is GNOME-like, only to find "gnome-open" missing and then
fall back on "fallback_browsers" instead of using a reasonable
alternative like "Xdg".
