### PR TITLE
Add iceweasel to *nix fallbacks

### DIFF
--- a/lib/launchy/detect/nix_desktop_environment.rb
+++ b/lib/launchy/detect/nix_desktop_environment.rb
@@ -19,7 +19,7 @@ module Launchy::Detect
     end
 
     def self.fallback_browsers
-      %w[ firefox seamonkey opera mozilla netscape galeon ].map { |x| ::Launchy::Argv.new( x ) }
+      %w[ firefox iceweasel seamonkey opera mozilla netscape galeon ].map { |x| ::Launchy::Argv.new( x ) }
     end
 
     def self.browsers


### PR DESCRIPTION
Hi there - thanks for the work on launchy, I've used it countless times with letter_opener.

I'm one of those people who runs an FSF approved linux distro and part of that is that firefox doesn't come as-is. The debian project maintains a fork of firefox called iceweasel that removes all the branding of firefox and other additions such as proprietary DRM wrappers (only mentioning for context). I also happen to run a derivative of Arch so gnome-open is actually called xdg-open on my system. I think because of firefox not being present in its usual form and gnome-open also not being present this was causing launchy to fail with a "Launchy::ApplicationNotFoundError:".

I realise that this may not affect a great deal of people but I think it'd be worth having in there as a fallback for the reason that Debian ships with iceweasel so those on a lesser used DE may also have this issue.
