### PR TITLE
Use 'kde-open' under KDE

### DIFF
--- a/lib/launchy/detect/nix_desktop_environment.rb
+++ b/lib/launchy/detect/nix_desktop_environment.rb
@@ -33,11 +33,11 @@ module Launchy::Detect
     class Kde < NixDesktopEnvironment
       def self.is_current_desktop_environment?
         ENV['KDE_FULL_SESSION'] &&
-          Launchy::Application.find_executable( 'kfmclient' )
+          Launchy::Application.find_executable( 'kde-open' )
       end
 
       def self.browser
-        ::Launchy::Argv.new( %w[ kfmclient openURL ] )
+        ::Launchy::Argv.new( 'kde-open' )
       end
     end
 


### PR DESCRIPTION
kde-open (like gnome-open) uses the user's configured preferred browser,
instead of assuming that they use Konqueror via kfmclient. kde-open is
part of kdebase-workspace (KDE4) and kde-cli-tools (KDE Frameworks 5)
and both are part of a KDE 'default desktop installation' - confirmed upstream.
