### PR TITLE
Recognize and handle mailto URI scheme for email addresses 

### DIFF
--- a/lib/launchy/applications/browser.rb
+++ b/lib/launchy/applications/browser.rb
@@ -4,7 +4,7 @@ class Launchy::Application
   #
   class Browser < Launchy::Application
     def self.schemes
-      %w[ http https ftp file ]
+      %w[ http https ftp file mailto]
     end
 
     def self.handles?( uri )


### PR DESCRIPTION
Enable opening the mailto email in the default mail client. Example:

```ruby
Launchy.open("mailto:someone@example.com")
```

will open mailto email address in the default mail client.
 