### PR TITLE
Stop passing -rubygems option to newer rubies

### DIFF
--- a/tasks/default.rake
+++ b/tasks/default.rake
@@ -38,7 +38,11 @@ task :develop => "develop:default"
 begin
   require 'rake/testtask'
   Rake::TestTask.new( :test ) do |t|
-    t.ruby_opts    = %w[ -w -rubygems ]
+    if RUBY_VERSION > "2.5"
+      t.ruby_opts    = %w[ -w ]
+    else
+      t.ruby_opts    = %w[ -w -rubygems ]
+    end
     t.libs         = %w[ lib spec test ]
     t.pattern      = "{test,spec}/**/{test_*,*_spec}.rb"
   end


### PR DESCRIPTION
As of Ruby 2.5 the `ubygems` option has been removed.

This checks the Ruby version, and passes the option
if it's available.