### PR TITLE
Fix the error "warning: deprecated Object#=~ ..."

### DIFF
--- a/lib/launchy/applications/browser.rb
+++ b/lib/launchy/applications/browser.rb
@@ -64,12 +64,12 @@ class Launchy::Application
     end
 
     def cmd_and_args( uri, options = {} )
-      cmd = browser_cmdline
+      cmd = browser_cmdline.to_s
       args = [ uri.to_s ]
       if cmd =~ /%s/ then
         cmd.gsub!( /%s/, args.shift )
       end
-      return [cmd, args]
+      [cmd, args]
     end
 
     # final assembly of the command and do %s substitution 


### PR DESCRIPTION
Ruby 2.7 now warns with 
> warning: deprecated Object#=~ is called on Launchy::Argv; it always returns nil

Cause: When Running Mint without any environment overrides set the `browser_cmdline` is `Argv[xdg-open]` 

Alternative solutions:
* change `if cmd =~ /%s/ then` to `if cmd.is_a?(String) && cmd =~ /%s/ then`
* Add `=~` and `gsub!` to `Argv`
